### PR TITLE
Feature/gpus on google cloud

### DIFF
--- a/elasticluster/share/playbooks/roles/cuda/tasks/init-Debian.yml
+++ b/elasticluster/share/playbooks/roles/cuda/tasks/init-Debian.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Set SLURM common playbook params (Debian/Ubuntu)
+  set_fact:
+    slurm_pid_dir: /var/run/slurm-llnl
+  when:
+    '{{is_debian_compatible}}'

--- a/elasticluster/share/playbooks/roles/cuda/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/cuda/tasks/init-RedHat.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Set SLURM common playbook params (RHEL 7.x compatible)
+  set_fact:
+    slurm_pid_dir: /var/run
+  when: 'is_rhel_compatible'

--- a/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
@@ -2,18 +2,18 @@
 #
 # Set up the cuda 
 #
-- name: CUDA | Check prior installation of cuda-8-0
+- name: Check prior installation of cuda-8-0
   command: dpkg-query -W cuda-8-0
   register: cuda_repo_ubuntu_install_check
   ignore_errors: yes
   changed_when: "{{cuda_repo_ubuntu_install_check | failed}}"
-- name: CUDA | Download deb package for Ubuntu 16.04
+- name: Download deb package for Ubuntu 16.04
   get_url:
     url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
     dest: /tmp/cuda_install.deb
     checksum: md5:1f4dffe1f79061827c807e0266568731
   when: "{{cuda_repo_ubuntu_install_check | failed}}"
-- name: CUDA | Install downloaded deb package for Ubuntu 16.04
+- name: Install downloaded deb package for Ubuntu 16.04
   apt:
     deb: /tmp/cuda_install.deb
   ignore_errors: yes
@@ -23,7 +23,7 @@
   apt:
      upgrade: yes
      update_cache: yes  
-- name: CUDA | Install cuda-8-0
+- name: Install cuda-8-0
   apt:
     name={{item}}
     state=latest
@@ -35,7 +35,7 @@
 # fill later. if it does, no need to restart
 # if it doesnt something must have gone wrong
 
-- name: CUDA | Add /usr/local/cuda-8.0/bin to PATH
+- name: Add /usr/local/cuda-8.0/bin to PATH
   vars:
     cuda_path: /usr/local/cuda-8.0
   lineinfile:
@@ -44,7 +44,7 @@
     backrefs: yes
     regexp: 'PATH=(["]*)((?!.*?{{cuda_path}}/bin).*?)(["]*)$'
     line: 'PATH=\1"{{cuda_path}}/bin":\2\3'
-- name: CUDA | restart server for NVIDIA driver
+- name: restart server for NVIDIA driver
   shell: sleep 2 && /sbin/shutdown -r now "Rebooting for CUDA driver"
   async: 1
   poll: 0
@@ -54,10 +54,6 @@
   when: "{{cuda_repo_ubuntu_install_check | failed}}" 
 - set_fact: wait_host="{{ ansible_host }}"
 - name: waiting for server to come back after reboot
-  local_action: wait_for host={{wait_host}} port=22 state=started delay=15 connect_timeout=300
+  local_action: wait_for host={{wait_host}} port=22 state=started delay=60 timeout=300 search_regex=OpenSSH
   become: false
   when: "{{cuda_repo_ubuntu_install_check | failed}}"
-# reload 
-- name: Load distribution-specific parameters
-  include: 'init-{{ansible_os_family}}.yml'
-  

--- a/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+#
+# Set up the cuda 
+#
+- name: CUDA | Check prior installation of cuda-8-0
+  command: dpkg-query -W cuda-8-0
+  register: cuda_repo_ubuntu_install_check
+  ignore_errors: yes
+  changed_when: "{{cuda_repo_ubuntu_install_check | failed}}"
+- name: CUDA | Download deb package for Ubuntu 16.04
+  get_url:
+    url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+    dest: /tmp/cuda_install.deb
+    checksum: md5:1f4dffe1f79061827c807e0266568731
+  when: "{{cuda_repo_ubuntu_install_check | failed}}"
+- name: CUDA | Install downloaded deb package for Ubuntu 16.04
+  apt:
+    deb: /tmp/cuda_install.deb
+  ignore_errors: yes
+  when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+- name: Update and upgrade apt packages
+  become: true
+  apt:
+     upgrade: yes
+     update_cache: yes  
+- name: CUDA | Install cuda-8-0
+  apt:
+    name={{item}}
+    state=latest
+  with_items:
+    - cuda-8-0
+  when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+  become: yes
+#- name: CUDA | check /dev/nvidia* exists
+# fill later. if it does, no need to restart
+# if it doesnt something must have gone wrong
+
+- name: CUDA | Add /usr/local/cuda-8.0/bin to PATH
+  vars:
+    cuda_path: /usr/local/cuda-8.0
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    backrefs: yes
+    regexp: 'PATH=(["]*)((?!.*?{{cuda_path}}/bin).*?)(["]*)$'
+    line: 'PATH=\1"{{cuda_path}}/bin":\2\3'
+- name: CUDA | restart server for NVIDIA driver
+  shell: sleep 2 && /sbin/shutdown -r now "Rebooting for CUDA driver"
+  async: 1
+  poll: 0
+  become: yes
+  become_method: sudo
+  ignore_errors: true
+  when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+- set_fact: wait_host="{{ ansible_host }}"
+- name: waiting for server to come back after reboot
+  local_action: wait_for host={{wait_host}} port=22 state=started delay=15 connect_timeout=300
+  become: false
+  when: "{{cuda_repo_ubuntu_install_check | failed}}"
+# reload 
+- name: Load distribution-specific parameters
+  include: 'init-{{ansible_os_family}}.yml'
+  

--- a/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
+++ b/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
@@ -75,7 +75,12 @@ AcctGatherFilesystemType=acct_gather_filesystem/none
 AcctGatherProfileType=acct_gather_profile/none
 #AcctGatherProfileType=acct_gather_profile/hdf5
 
-JobAcctGatherType=jobacct_gather/linux
+
+####
+## Changed by Hatef Monajemi to get rid of memory error
+## When using SLURM with GPUs
+#JobAcctGatherType=jobacct_gather/linux
+JobAcctGatherType=jobacct_gather/none
 JobAcctGatherFrequency=60
 
 

--- a/elasticluster/share/playbooks/site.yml
+++ b/elasticluster/share/playbooks/site.yml
@@ -41,6 +41,11 @@
         deb: /tmp/cuda_install.deb
       ignore_errors: yes
       when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+    - name: Update and upgrade apt packages
+      become: true
+      apt:
+         upgrade: yes
+         update_cache: yes  
     - name: CUDA | Install cuda-8-0
       apt:
         name={{item}}
@@ -50,7 +55,8 @@
       when: "{{cuda_repo_ubuntu_install_check | failed}}" 
       become: yes
     #- name: CUDA | check /dev/nvidia* exists
-      # fill later
+    # fill later. if it does, no need to restart
+	# if it doesnt something must have gone wrong
     - name: restart server
       shell: sleep 2 && /sbin/shutdown -r now "Rebooting for CUDA driver"
       async: 1

--- a/elasticluster/share/playbooks/site.yml
+++ b/elasticluster/share/playbooks/site.yml
@@ -25,7 +25,7 @@
       ntp_server: '{{groups.ntp_master|default([])}}'
     - role: pdsh
     - role: cuda
-  tasks:
+  tasks:  
     - name: Gather information about GPUs
       action: gpus
 # Run all other playbooks one by one, so they get a chance of doing

--- a/elasticluster/share/playbooks/site.yml
+++ b/elasticluster/share/playbooks/site.yml
@@ -25,9 +25,47 @@
       ntp_server: '{{groups.ntp_master|default([])}}'
     - role: pdsh
   tasks:
+    - name: Check if cuda is installed
+      command: dpkg-query -W cuda-8-0
+      register: cuda_repo_ubuntu_install_check
+      ignore_errors: yes
+      changed_when: "{{cuda_repo_ubuntu_install_check | failed}}"
+    - name: CUDA | Download deb package for Ubuntu 16.04
+      get_url:
+        url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+        dest: /tmp/cuda_install.deb
+        checksum: md5:1f4dffe1f79061827c807e0266568731
+      when: "{{cuda_repo_ubuntu_install_check | failed}}"
+    - name: CUDA | Install downloaded deb package for Ubuntu 16.04
+      apt:
+        deb: /tmp/cuda_install.deb
+      ignore_errors: yes
+      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+    - name: CUDA | Install cuda-8-0
+      apt:
+        name={{item}}
+        state=latest
+      with_items:
+        - cuda-8-0
+      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+      become: yes
+    #- name: CUDA | check /dev/nvidia* exists
+      # fill later
+    - name: restart server
+      shell: sleep 2 && /sbin/shutdown -r now "Rebooting for CUDA driver"
+      async: 1
+      poll: 0
+      become: yes
+      become_method: sudo
+      ignore_errors: true
+      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
+    - set_fact: wait_host="{{ ansible_host }}"
+    - name: waiting for server to come back after reboot
+      local_action: wait_for host={{wait_host}} port=22 state=started delay=15 connect_timeout=300
+      become: false
+      when: "{{cuda_repo_ubuntu_install_check | failed}}"
     - name: Gather information about GPUs
       action: gpus
-
 # Run all other playbooks one by one, so they get a chance of doing
 # their setup depending on configured host groups
 - include: roles/ansible.yml

--- a/elasticluster/share/playbooks/site.yml
+++ b/elasticluster/share/playbooks/site.yml
@@ -24,52 +24,8 @@
     - role: ntpd
       ntp_server: '{{groups.ntp_master|default([])}}'
     - role: pdsh
+    - role: cuda
   tasks:
-    - name: Check if cuda is installed
-      command: dpkg-query -W cuda-8-0
-      register: cuda_repo_ubuntu_install_check
-      ignore_errors: yes
-      changed_when: "{{cuda_repo_ubuntu_install_check | failed}}"
-    - name: CUDA | Download deb package for Ubuntu 16.04
-      get_url:
-        url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
-        dest: /tmp/cuda_install.deb
-        checksum: md5:1f4dffe1f79061827c807e0266568731
-      when: "{{cuda_repo_ubuntu_install_check | failed}}"
-    - name: CUDA | Install downloaded deb package for Ubuntu 16.04
-      apt:
-        deb: /tmp/cuda_install.deb
-      ignore_errors: yes
-      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
-    - name: Update and upgrade apt packages
-      become: true
-      apt:
-         upgrade: yes
-         update_cache: yes  
-    - name: CUDA | Install cuda-8-0
-      apt:
-        name={{item}}
-        state=latest
-      with_items:
-        - cuda-8-0
-      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
-      become: yes
-    #- name: CUDA | check /dev/nvidia* exists
-    # fill later. if it does, no need to restart
-	# if it doesnt something must have gone wrong
-    - name: restart server
-      shell: sleep 2 && /sbin/shutdown -r now "Rebooting for CUDA driver"
-      async: 1
-      poll: 0
-      become: yes
-      become_method: sudo
-      ignore_errors: true
-      when: "{{cuda_repo_ubuntu_install_check | failed}}" 
-    - set_fact: wait_host="{{ ansible_host }}"
-    - name: waiting for server to come back after reboot
-      local_action: wait_for host={{wait_host}} port=22 state=started delay=15 connect_timeout=300
-      become: false
-      when: "{{cuda_repo_ubuntu_install_check | failed}}"
     - name: Gather information about GPUs
       action: gpus
 # Run all other playbooks one by one, so they get a chance of doing


### PR DESCRIPTION
@riccardomurri I have got your code and tried to add some code that automatically installs cuda-8-0. 
The two commits I made will basically change
        elasticluster/share/playbooks/site.yml 

It installs cuda-8-0, and reboots the servers before you inquire about GPUs. The code needs some cleaning and more checks. In particular, we need to only trigger this installation if the user asks for GPU accelerator. Currently, we don't constraint. Would you be able to add these?

Thank you so much again for all your efforts to make this happen. We are on track!
Regarding the work-around with custom-made images, I thought that approach will be
more work for people, as they each need to generate the image from another image in their 
own project. It is unfortunate that GCE doesn't offer a NVIDIA-equipped image while AWS does!

Please let me know what you think of my changes. You may not approve that I am rebooting in the middle, but everything goes smoothly with the current code!

Looking forward to hearing from you. 
Hatef 
 