### PR TITLE
Ensure newly added floating ips are used to connect to the a newly created cluster

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -1258,7 +1258,9 @@ class Node(Struct):
         for ip in itertools.chain([self.preferred_ip], ips):
             if not ip:
                 continue
-            log.debug("Trying to connect to host %s (%s) ...", self.name, ip)
+            log.debug(
+                "Trying to connect to host %s using IP address %s ...",
+                self.name, ip)
             try:
                 addr, port = parse_ip_address_and_port(ip, SSH_PORT)
                 extra = {

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -105,6 +105,7 @@ SCHEMA = {
         'nodes': {
             str: {
                 'flavor': nonempty_str,
+                Optional('floating_network_id'): str,
                 'image_id': nonempty_str,
                 Optional('image_userdata', default=''): str,
                 Optional('security_group', default='default'): str,  ## FIXME: alphanumeric?
@@ -662,6 +663,7 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
     kind_values = {}
     for attr in (
             'flavor',
+            'floating_network_id',
             'image_id',
             #'image_user',       ## from `login/*`
             'image_userdata',

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -563,8 +563,14 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         """
         self._init_os_api()
         instance = self._load_instance(instance_id)
-        IPs = sum(instance.networks.values(), [])
-        return IPs
+        try:
+            ip_addrs = set([self.floating_ip])
+        except AttributeError:
+            ip_addrs = set([])
+        for ip_addr in sum(instance.networks.values(), []):
+            ip_addrs.add(ip_addr)
+        log.debug("VM `%s` has IP addresses %r", instance_id, ip_addrs)
+        return list(ip_addrs)
 
     def is_instance_running(self, instance_id):
         """Checks if the instance is up and running.

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -3,7 +3,7 @@
 # @(#)openstack.py
 #
 #
-# Copyright (C) 2013, 2015 S3IT, University of Zurich. All rights reserved.
+# Copyright (C) 2013, 2015, 2018 University of Zurich. All rights reserved.
 #
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -829,7 +829,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 # networks to be connected to a VM, but does not give any
                 # hint as to which one(s) should be used for such requests.
                 # So we try them all, ignoring errors until one request
-                # succeeds and hope that it's the OK. One can imagine
+                # succeeds and hope that it's OK. One can imagine
                 # scenarios where this is *not* correct, but: (1) these
                 # scenarios are unlikely, and (2) the old novaclient code
                 # above has not even had the concept of multiple networks

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -920,8 +920,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                     .format(network_ids, instance.name, instance.id))
             # assign floating IP to port
             floating_ip = self.neutron_client.update_floatingip(
-                floating_ip,
-                'floatingip': {
+                floating_ip['id'],
+                {'floatingip': {
                     'port_id': port_id,
                 },
             }).get('floatingip')

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -512,10 +512,15 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 floating_ips = [ip for ip in self.nova_client.floating_ips.list()
                                 if ip.instance_id == vm.id]
             except AttributeError:
-                floating_ips = self.neutron_client.list_floatingips(id=vm.id)['floatingips']
+                floating_ips = (
+                    self.neutron_client
+                    .list_floatingips(id=vm.id)
+                    .get('floating_ips', []))
             # allocate new floating IP if none given
             if not floating_ips:
                 self._allocate_address(vm, network_ids)
+            else:
+                log.debug("VM `%s` already allocated floating IPs: %r", vm.id, floating_ips)
 
         self._instances[vm.id] = vm
 
@@ -736,71 +741,129 @@ class OpenStackCloudProvider(AbstractCloudProvider):
             "Instance `{instance_id}` not found"
             .format(instance_id=instance_id))
 
+
     def _allocate_address(self, instance, network_ids):
         """
-        Allocates a floating/public ip address to the given instance.
+        Allocates a floating/public ip address to the given instance,
+        dispatching to either the Compute or Network API depending
+        on installed packages.
 
         :param instance: instance to assign address to
 
-        :param list network_id: List of IDs (as strings) of networks where to
-        request allocation the floating IP.
+        :param list network_id: List of IDs (as strings) of networks
+          where to request allocation the floating IP.
+
+        :return: public ip address
+        """
+        try:
+            # on python-novaclient>=8.0.0 this fails with
+            # `AttributeError` since the `Client.floating_ips`
+            # attribute has been removed
+            return self._allocate_address_nova(instance, network_ids)
+        except AttributeError:
+            return self._allocate_address_neutron(instance, network_ids)
+
+
+    def _allocate_address_nova(self, instance, network_ids):
+        """
+        Allocates a floating/public ip address to the given instance,
+        using the OpenStack Compute ('Nova') API.
+
+        :param instance: instance to assign address to
+
+        :param list network_id: List of IDs (as strings) of networks
+          where to request allocation the floating IP.  **Ignored**
+          (only used by the corresponding Neutron API function).
 
         :return: public ip address
         """
         self._init_os_api()
         with OpenStackCloudProvider.__node_start_lock:
-            try:
-                # Use the `novaclient` API (works with python-novaclient <8.0.0)
-                free_ips = [ip for ip in self.nova_client.floating_ips.list() if not ip.fixed_ip]
-                if not free_ips:
-                    free_ips.append(self.nova_client.floating_ips.create())
-            except AttributeError:
-                # Use the `neutronclient` API
-                #
-                # for some obscure reason, using `fixed_ip_address=None` in the
-                # call to `list_floatingips()` returns *no* results (not even,
-                # in fact, those with `fixed_ip_address: None`) whereas
-                # `fixed_ip_address=''` acts as a wildcard and lists *all* the
-                # addresses... so filter them out with a list comprehension
-                free_ips = [ip for ip in
-                            self.neutron_client.list_floatingips(fixed_ip_address='')['floatingips']
-                            if ip['fixed_ip_address'] is None]
-                if not free_ips:
-                    # FIXME: OpenStack Network API v2 requires that we specify
-                    # a network ID along with the request for a floating IP.
-                    # However, ElastiCluster configuration allows for multiple
-                    # networks to be connected to a VM, but does not give any
-                    # hint as to which one(s) should be used for such requests.
-                    # So we try them all, ignoring errors until one request
-                    # succeeds and hope that it's the OK. One can imagine
-                    # scenarios where this is *not* correct, but: (1) these
-                    # scenarios are unlikely, and (2) the old novaclient code
-                    # above has not even had the concept of multiple networks
-                    # for floating IPs and no-one has complained in 5 years...
-                    allocated_ip = None
-                    for network_id in network_ids:
-                        log.debug(
-                            "Trying to allocate floating IP on network %s ...", network_id)
-                        try:
-                            allocated_ip = self.neutron_client.create_floatingip({
-                                'floatingip': {'floating_network_id':network_id}})
-                        except BadNeutronRequest as err:
-                            log.debug(
-                                "Failed allocating floating IP on network %s: %s",
-                                network_id, err)
-                        if allocated_ip:
-                            free_ips.append(allocated_ip)
-                            break
-                        else:
-                            continue  # try next network
+            # Use the `novaclient` API (works with python-novaclient <8.0.0)
+            free_ips = [ip for ip in self.nova_client.floating_ips.list() if not ip.fixed_ip]
+            if not free_ips:
+                log.debug("Trying to allocate a new floating IP ...")
+                free_ips.append(self.nova_client.floating_ips.create())
             if free_ips:
                 ip = free_ips.pop()
             else:
                 raise RuntimeError(
                     "Could not allocate floating IP for VM {0}"
-                    .format(vm.id))
+                    .format(instance_id))
             instance.add_floating_ip(ip)
         return ip.ip
+
+
+    def _allocate_address_neutron(self, instance, network_ids):
+        """
+        Allocates a floating/public ip address to the given instance,
+        using the OpenStack Network ('Neutron') API.
+
+        :param instance: instance to assign address to
+        :param list network_id:
+          List of IDs (as strings) of networks where to
+          request allocation the floating IP.
+
+        :return: public ip address
+        """
+        self._init_os_api()
+        with OpenStackCloudProvider.__node_start_lock:
+            ip_address = None
+            # for some obscure reason, using `fixed_ip_address=None` in the
+            # call to `list_floatingips()` returns *no* results (not even,
+            # in fact, those with `fixed_ip_address: None`) whereas
+            # `fixed_ip_address=''` acts as a wildcard and lists *all* the
+            # addresses... so filter them out with a list comprehension
+            free_ips = [
+                ip for ip in
+                self.neutron_client.list_floatingips(fixed_ip_address='').get('floatingips')
+                if ip['fixed_ip_address'] is None
+            ]
+            if free_ips:
+                ip_address = free_ips.pop()
+            else:
+                # FIXME: OpenStack Network API v2 requires that we specify
+                # a network ID along with the request for a floating IP.
+                # However, ElastiCluster configuration allows for multiple
+                # networks to be connected to a VM, but does not give any
+                # hint as to which one(s) should be used for such requests.
+                # So we try them all, ignoring errors until one request
+                # succeeds and hope that it's the OK. One can imagine
+                # scenarios where this is *not* correct, but: (1) these
+                # scenarios are unlikely, and (2) the old novaclient code
+                # above has not even had the concept of multiple networks
+                # for floating IPs and no-one has complained in 5 years...
+                for network_id in network_ids:
+                    log.debug(
+                        "Trying to allocate floating IP on network %s ...", network_id)
+                    try:
+                        resp = self.neutron_client.create_floatingip({
+                            'floatingip': {
+                                'floating_network_id':network_id,
+                            }}).get('floatingip')
+                        ip_address = resp['floating_ip_address']
+                        log.debug("Allocated IP address %s on network %s", ip_address, network_id)
+                        break  # stop at first network where we get a floating IP
+                    except BadNeutronRequest as err:
+                        log.debug(
+                            "Failed allocating floating IP on network %s: %s",
+                            network_id, err)
+            if ip_address is None:
+                raise RuntimeError(
+                    "Could not allocate floating IP for VM {0}"
+                    .format(instance_id))
+            # get port ID
+            port_id = self.nova_client.interface_list(instance.id)  # FIXMEEE
+            # assign floating IP to port
+            resp = self.neutron_client.update_floatingip({
+                'floatingip': {
+                    'id': ...,  # FIXMEEE
+                    'port': port_id,
+                }}).get('floatingip')
+            ip_address = resp['floating_ip_address']
+            log.debug("Assigned IP address %s to port %s", ip_address, network_id)
+        return ip_address
+
 
     # Fix pickler
     def __getstate__(self):

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -934,6 +934,17 @@ class OpenStackCloudProvider(AbstractCloudProvider):
             }).get('floatingip')
             ip_address = floating_ip['floating_ip_address']
             log.debug("Assigned IP address %s to port %s", ip_address, port_id)
+
+            log.info("Waiting 300s until floating IP %s is ACTIVE", ip_address)
+            for i in range(300):
+                _floating_ip = self.neutron_client.show_floatingip(floating_ip['id'])
+                if _floating_ip['floatingip']['status'] != 'DOWN':
+                    break
+                sleep(1)
+
+            # Invalidate cache for this VM, as we just assigned a new IP
+            if instance.id in self._cached_instances[]:
+                del self._cached_instances[instance.id]
         return ip_address
 
 

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -537,7 +537,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                     .get('floating_ips', []))
             # allocate new floating IP if none given
             if not floating_ips:
-                self._allocate_address(vm, floating_networks)
+                ip_addr = self._allocate_address(vm, floating_networks)
+                log.debug("VM `%s` was allocated floating IP: %r", vm.id, ip_addr)
             else:
                 log.debug("VM `%s` already allocated floating IPs: %r", vm.id, floating_ips)
 


### PR DESCRIPTION
When associating a floating IP to a VM we now wait until the floating IP
is in `ACTIVE` state and then we purge the VM from the cache of the
OpenStack provider, so that when needed the list of IPs will be
refreshed and will contain also the newly added floating IP.